### PR TITLE
노트 페이지 내 SpanishKeyboard 컴포넌트 적용

### DIFF
--- a/components/SpanishInput.tsx
+++ b/components/SpanishInput.tsx
@@ -7,6 +7,7 @@ interface ISpanishInput {
   setValue?: Dispatch<SetStateAction<string>>;
   disabled?: boolean;
   inputRef?: RefObject<HTMLInputElement>;
+  open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
   setSpecialChar: Dispatch<SetStateAction<keyof typeof SpanishConvertDict | null>>;
   setIsActiveSpanishKeyboard: Dispatch<SetStateAction<boolean>>;
@@ -20,28 +21,24 @@ export default function SpanishInput({
   setValue,
   disabled,
   inputRef,
+  open,
   setOpen,
   setSpecialChar,
   setIsActiveSpanishKeyboard,
 }: ISpanishInput) {
   const keypressEventHandler = (e: KeyboardEvent<HTMLInputElement>) => {
     if (!e.ctrlKey && !e.metaKey) {
-      if (TargetSpanishCharListForInput.includes(e.key) || PossibleOtherKeys.includes(e.key)) {
-        if (PossibleOtherKeys.includes(e.key)) {
-          inputRef?.current?.blur();
-          setIsActiveSpanishKeyboard(true);
-        } else {
-          setOpen(true);
-          setIsActiveSpanishKeyboard(false);
-          setSpecialChar(e.key as keyof typeof SpanishConvertDict);
-        }
+      if (TargetSpanishCharListForInput.includes(e.key)) {
+        setOpen(true);
+        setIsActiveSpanishKeyboard(false);
+        setSpecialChar(e.key as keyof typeof SpanishConvertDict);
+      } else if (PossibleOtherKeys.includes(e.key) && open) {
+        inputRef?.current?.blur();
+        setIsActiveSpanishKeyboard(true);
       } else {
         setOpen(false);
         setSpecialChar(null);
       }
-    } else {
-      setOpen(false);
-      setSpecialChar(null);
     }
   };
 

--- a/components/SpanishInput.tsx
+++ b/components/SpanishInput.tsx
@@ -1,5 +1,5 @@
 import { Dispatch, KeyboardEvent, RefObject, SetStateAction } from 'react';
-import { TargetSpanishCharListForInput, SpanishConvertDict } from '@/def';
+import { TargetSpanishCharListForInput, SpanishConvertDict, SpanishKeyboardActivationKey } from '@/def';
 
 interface ISpanishInput {
   value: string;
@@ -12,8 +12,6 @@ interface ISpanishInput {
   setSpecialChar: Dispatch<SetStateAction<keyof typeof SpanishConvertDict | null>>;
   setIsActiveSpanishKeyboard: Dispatch<SetStateAction<boolean>>;
 }
-
-const PossibleOtherKeys = ['ArrowUp'];
 
 export default function SpanishInput({
   value,
@@ -32,7 +30,7 @@ export default function SpanishInput({
         setOpen(true);
         setIsActiveSpanishKeyboard(false);
         setSpecialChar(e.key as keyof typeof SpanishConvertDict);
-      } else if (PossibleOtherKeys.includes(e.key) && open) {
+      } else if (e.key === SpanishKeyboardActivationKey && open) {
         inputRef?.current?.blur();
         setIsActiveSpanishKeyboard(true);
       } else {

--- a/components/SpanishKeyboard.tsx
+++ b/components/SpanishKeyboard.tsx
@@ -50,16 +50,16 @@ export default function SpanishKeyboard({ specialChar, onClose, charClickHandler
   }, [escKeydownHandler]);
 
   return (
-    <div className='absolute z-10 left-0 bottom-full h-12 w-20 rounded-lg'>
-      <div className='flex justify-center items-center bg-gray-500 opacity-80 text-white rounded-lg h-full'>
+    <div className='absolute z-10 left-0 bottom-full h-12 w-20 opacity-80 text-white'>
+      <div className='flex justify-center items-center h-full'>
         <div className='w-full h-full flex'>
           {SpanishConvertDict[specialChar].map((ch, index) => {
-            const style =
-              'w-full h-full flex justify-center items-center cursor-pointer hover:bg-highFever ' +
-              (index === current ? 'bg-highFever' : 'bg-gray-500');
-
             return (
-              <div key={`specialKeyboard` + ch} className={style} onClick={() => charClickHandler(ch)}>
+              <div
+                key={`specialKeyboard` + ch}
+                className={getSpecialKeyboardStyle(SpanishConvertDict[specialChar].length, index, current)}
+                onClick={() => charClickHandler(ch)}
+              >
                 {ch}
               </div>
             );
@@ -68,4 +68,25 @@ export default function SpanishKeyboard({ specialChar, onClose, charClickHandler
       </div>
     </div>
   );
+}
+
+function getSpecialKeyboardStyle(length: number, index: number, current: number) {
+  let base = 'w-full h-full flex justify-center items-center cursor-pointer hover:bg-highFever';
+
+  if (index === current) {
+    base += ' bg-highFever';
+  } else {
+    base += ' bg-gray-500';
+  }
+
+  if (length === 1) {
+    base += ' rounded-md';
+  } else {
+    if (index === 0) {
+      base += ' rounded-l-md';
+    } else {
+      base += ' rounded-r-md';
+    }
+  }
+  return base;
 }

--- a/components/SpanishKeyboard.tsx
+++ b/components/SpanishKeyboard.tsx
@@ -5,7 +5,7 @@ import { SpanishConvertDict } from '@/def';
 
 type Props = {
   specialChar: keyof typeof SpanishConvertDict;
-  inputRef: RefObject<HTMLInputElement>;
+  inputRef: RefObject<HTMLInputElement | HTMLTextAreaElement>;
   charClickHandler: (char: string) => void;
   onClose: () => void;
   isActiveSpanishKeyboard: boolean;
@@ -50,7 +50,7 @@ export default function SpanishKeyboard({ specialChar, onClose, charClickHandler
   }, [escKeydownHandler]);
 
   return (
-    <div className='absolute z-10 bottom-12 h-12 w-20 rounded-lg'>
+    <div className='absolute z-10 left-0 bottom-full h-12 w-20 rounded-lg'>
       <div className='flex justify-center items-center bg-gray-500 opacity-80 text-white rounded-lg h-full'>
         <div className='w-full h-full flex'>
           {SpanishConvertDict[specialChar].map((ch, index) => {

--- a/components/enroll-spanish.tsx
+++ b/components/enroll-spanish.tsx
@@ -145,6 +145,7 @@ export default function EnrollSpanish({
           placeholder='Español'
           setValue={setSpanish}
           inputRef={inputRef}
+          open={open}
           setOpen={(isOpen) => setOpen(isOpen)}
           setSpecialChar={setSpecialChar}
           setIsActiveSpanishKeyboard={setIsActiveSpanishKeyboard}

--- a/components/note/enroll-note.tsx
+++ b/components/note/enroll-note.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { Dispatch, SetStateAction, useCallback, useState } from 'react';
+import { Dispatch, SetStateAction, useCallback, useState, useRef, KeyboardEvent } from 'react';
 import NoteMarkdown from './note-markdown';
 import { enrollNote, modifyNote } from '@/service/note';
 import { useAuthContext } from '@/context/authContext';
 import { NoteStateType } from '@/types';
-import { NoteState } from '@/def';
+import { NoteState, SpanishConvertDict, TargetSpanishCharListForInput } from '@/def';
 import Button from '../button';
+import SpanishKeyboard from '../SpanishKeyboard';
 
 type Props = {
   setNoteState: Dispatch<SetStateAction<NoteStateType>>;
@@ -17,9 +18,16 @@ type Props = {
   requestFirstNote: () => void;
 };
 
+const PossibleOtherKeys = ['ArrowUp'];
+
 export default function EnrollNote({ setNoteState, noteState, content, noteId, setContent, requestFirstNote }: Props) {
   const [note, setNote] = useState(content ?? '');
+  const [open, setOpen] = useState(false);
+  const [specialChar, setSpecialChar] = useState<keyof typeof SpanishConvertDict | null>(null);
+  const [isActiveSpanishKeyboard, setIsActiveSpanishKeyboard] = useState(false);
   const { user } = useAuthContext();
+
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   const onEnrollHandler = useCallback(async () => {
     const userId = user?.uid;
@@ -56,14 +64,60 @@ export default function EnrollNote({ setNoteState, noteState, content, noteId, s
     }
   }, [note, user, setNoteState, setContent, noteId]);
 
+  const charClickHandler = (char: string) => {
+    const currentCursorLocation = textAreaRef.current?.selectionStart as number;
+    setNote(note.slice(0, currentCursorLocation - 1) + char + note.slice(currentCursorLocation));
+
+    setOpen(false);
+    setIsActiveSpanishKeyboard(false);
+
+    setTimeout(() => {
+      textAreaRef.current?.focus();
+      textAreaRef.current?.setSelectionRange(currentCursorLocation + 1, currentCursorLocation);
+    }, 0);
+  };
+
+  const onModalCloseHandler = () => {
+    setOpen(false);
+    setIsActiveSpanishKeyboard(false);
+    textAreaRef.current?.focus();
+  };
+
+  const keypressEventHandler = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!e.ctrlKey && !e.metaKey) {
+      if (TargetSpanishCharListForInput.includes(e.key)) {
+        setOpen(true);
+        setIsActiveSpanishKeyboard(false);
+        setSpecialChar(e.key as keyof typeof SpanishConvertDict);
+      } else if (PossibleOtherKeys.includes(e.key) && open) {
+        textAreaRef?.current?.blur();
+        setIsActiveSpanishKeyboard(true);
+      } else {
+        setOpen(false);
+        setSpecialChar(null);
+      }
+    }
+  };
+
   return (
     <section className='flex flex-col items-center w-full h-full'>
-      <div className='flex gap-2 w-4/5 h-full'>
+      <div className='flex gap-2 w-4/5 h-full relative'>
         <textarea
+          ref={textAreaRef}
           className='w-full h-full rounded-md lg:w-1/2'
           value={note}
+          onKeyDown={keypressEventHandler}
           onChange={(e) => setNote(e.target.value)}
         />
+        {open && specialChar && (
+          <SpanishKeyboard
+            specialChar={specialChar}
+            inputRef={textAreaRef}
+            charClickHandler={charClickHandler}
+            onClose={onModalCloseHandler}
+            isActiveSpanishKeyboard={isActiveSpanishKeyboard}
+          />
+        )}
         <NoteMarkdown markdown={note} width='half' />
       </div>
       <div className='my-5'>

--- a/components/note/enroll-note.tsx
+++ b/components/note/enroll-note.tsx
@@ -5,7 +5,7 @@ import NoteMarkdown from './note-markdown';
 import { enrollNote, modifyNote } from '@/service/note';
 import { useAuthContext } from '@/context/authContext';
 import { NoteStateType } from '@/types';
-import { NoteState, SpanishConvertDict, TargetSpanishCharListForInput } from '@/def';
+import { NoteState, SpanishConvertDict, TargetSpanishCharListForInput, SpanishKeyboardActivationKey } from '@/def';
 import Button from '../button';
 import SpanishKeyboard from '../SpanishKeyboard';
 
@@ -17,8 +17,6 @@ type Props = {
   setContent: Dispatch<SetStateAction<string>>;
   requestFirstNote: () => void;
 };
-
-const PossibleOtherKeys = ['ArrowUp'];
 
 export default function EnrollNote({ setNoteState, noteState, content, noteId, setContent, requestFirstNote }: Props) {
   const [note, setNote] = useState(content ?? '');
@@ -89,7 +87,7 @@ export default function EnrollNote({ setNoteState, noteState, content, noteId, s
         setOpen(true);
         setIsActiveSpanishKeyboard(false);
         setSpecialChar(e.key as keyof typeof SpanishConvertDict);
-      } else if (PossibleOtherKeys.includes(e.key) && open) {
+      } else if (e.key === SpanishKeyboardActivationKey && open) {
         textAreaRef?.current?.blur();
         setIsActiveSpanishKeyboard(true);
       } else {

--- a/def.ts
+++ b/def.ts
@@ -69,3 +69,5 @@ export const SpanishConvertDict = {
   '?': ['¿'],
   '!': ['¡'],
 };
+
+export const SpanishKeyboardActivationKey = 'ArrowUp';


### PR DESCRIPTION
## 한 줄 요약
노트 입력 시 스페인 알파벳 강조 등을 입력할 수 있게 함

## 작업 내용
단어/문장 페이지에서 스페인어 입력에 사용한 SpanishKeyboard 컴포넌트를 적용함.

## 이슈 번호/링크(필요 시)
-